### PR TITLE
README.md: the file TUTORIAL.MD has been renamed to GETTING_STARTED.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Pyretic runtime (interpreter) system.
 See http://frenetic-lang.org/pyretic/ for more info.
 
 top-level:
-- CONTRIBS.md:  Guidelines for contributing to Pyretic codebase
+- CONTRIB.md:   Guidelines for contributing to Pyretic codebase
 - of_client:    Clients that run on a traditional OpenFlow controller
                 effectively serving as a backend for Pyretic
 - mininet:      Slightly modified version of mininet mn 
@@ -15,4 +15,4 @@ top-level:
 - pyretic:      Pyretic system proper 
 - pyretic.py:   A wrapper that starts up Pyretic
                 and optionally an OpenFlow client (see above)
-- TUTORIAL.md:  Brief instructions for running example Pyretic programs
+- GETTING_STARTED.md: Brief instructions for running example Pyretic programs


### PR DESCRIPTION
The file TUTORIAL.md was renamed to GETTING_STARTED.md in commit
74f467f59fcd6f26b222645587f75723ed004896.  Also corrected the name of
the CONTRIB.md file (s/CONTRIBS.md/CONTRIB.md/).
