### PR TITLE
Fixed modify() to also be able to change packets' srcport and dstport

### DIFF
--- a/of_client/pox_client.py
+++ b/of_client/pox_client.py
@@ -427,6 +427,10 @@ class POXClient(revent.EventMixin):
                 of_actions.append(of.ofp_action_nw_addr.set_src(actions['srcip']))
             if 'dstip' in actions:
                 of_actions.append(of.ofp_action_nw_addr.set_dst(actions['dstip']))
+            if 'srcport' in actions:
+                of_actions.append(of.ofp_action_tp_port.set_src(actions['srcport']))
+            if 'dstport' in actions:
+                of_actions.append(of.ofp_action_tp_port.set_dst(actions['dstport']))
             if 'vlan_id' in actions:
                 if actions['vlan_id'] is None:
                     of_actions.append(of.ofp_action_strip_vlan())


### PR DESCRIPTION
Hey Pyretic team,

I was doing some work with Pyretic and I was trying to use the modify method to change the source and destination ports of the packet but it wasn't working. I looked through the `pox_client` and noticed that when installing the open flow actions it would only install an action to modify the source MAC or IP or the destination MAC or IP, but not the source or destination port. All I did to solve this problem was add lines to use the POX method to set the correct action if a source or destination port action was requested.

Best,
Etan Zapinsky
