### PR TITLE
Fix ValueError when deleting rules

### DIFF
--- a/pyretic/core/runtime.py
+++ b/pyretic/core/runtime.py
@@ -1030,7 +1030,7 @@ class Runtime(object):
 
             if to_delete:
                 for rule in to_delete:
-                    (match_dict,priority,_,_) = rule
+                    (match_dict,priority,_,_,_) = rule
                     if match_dict['switch'] in switches:
                         self.delete_rule((match_dict, priority))
             if to_add:


### PR DESCRIPTION
The rule tuple contains five values, not four.

Signed-off-by: James Guthrie <james@prodigi.ch>