### PR TITLE
Check if backend is valid during shutdown

### DIFF
--- a/pyretic.py
+++ b/pyretic.py
@@ -50,8 +50,9 @@ def signal_handler(signal, frame):
     print '\n----starting pyretic shutdown------'
     # for thread in threading.enumerate():
     #     print (thread,thread.isAlive())
-    print "attempting to kill of_client"
-    of_client.kill()
+    if of_client:
+        print "attempting to kill of_client"
+        of_client.kill()
     # print "attempting get output of of_client:"
     # output = of_client.communicate()[0]
     # print output


### PR DESCRIPTION
In frontend-only mode the backend is initialized to None, so calling its
kill() member function fails.

Fixes frenetic-lang/pyretic#31.

Signed-off-by: James Guthrie <james@prodigi.ch>