### PR TITLE
pox_client: bugfix printing traces

### DIFF
--- a/of_client/pox_client.py
+++ b/of_client/pox_client.py
@@ -287,7 +287,7 @@ class POXClient(revent.EventMixin):
         if self.show_traces:
             print "========= POX/OF SEND ================"
             print msg
-            print packetlib.ethernet(msg._get_data())
+            print packetlib.ethernet(msg.data)
             print
 
         ## HANDLE PACKETS SEND ON LINKS THAT HAVE TIMED OUT


### PR DESCRIPTION
Pox's ofp_packet_out class no longer has the _get_data() member